### PR TITLE
Fix create table errors in mview sync by removing redirect.

### DIFF
--- a/includes/nd_genotypes.mview.inc
+++ b/includes/nd_genotypes.mview.inc
@@ -112,7 +112,7 @@ function nd_genotypes_create_mview_ndg_variants($tablename = 'mview_ndg_variants
     'indexes' => array(    ),
   );
 
-  chado_create_custom_table( $tablename, $schema );
+  chado_create_custom_table( $tablename, $schema, TRUE, NULL, FALSE );
 
 }
 
@@ -319,7 +319,7 @@ function nd_genotypes_create_mview_ndg_calls($tablename = 'mview_ndg_calls') {
     'indexes' => array(),
   );
 
-  chado_create_custom_table( $tablename, $schema );
+  chado_create_custom_table($tablename, $schema, TRUE, NULL, FALSE);
 
 }
 
@@ -437,7 +437,7 @@ function nd_genotypes_create_mview_ndg_germplasm_genotyped($table_name = 'mview_
     ),
   );
 
-  chado_create_custom_table( $table_name, $schema );
+  chado_create_custom_table( $table_name, $schema, TRUE, NULL, FALSE );
 
 }
 
@@ -507,7 +507,7 @@ function nd_genotypes_create_mview_summary($table_name = 'mview_ndg_summary') {
     'indexes' => array(),
   );
 
-  chado_create_custom_table( $table_name, $schema );
+  chado_create_custom_table( $table_name, $schema, TRUE, NULL, FALSE );
 
 }
 


### PR DESCRIPTION
Issue #11 

This PR fixes the bug originally reported by @carolyncaron. Specifically, it fixes an issue with the create mview tables during sync of this module. By default the tripal custom table creation function will redirect the admin back to the custom table page. When run from the command-line, calling a redirect causes `Cannot modify header information - headers already sent by (output started at             [warning] /usr/share/php/drush/includes/output.inc:37) common.inc:706`. Luckily the API allows us to specify that we don't want to redirect using the 5th parameter as shown here: http://api.tripal.info/api/tripal/tripal_chado%21api%21tripal_chado.custom_tables.api.inc/function/chado_create_custom_table/3.x

## Testing
1. Go to Admin > Tripal > Extentions > Natural Diversity Genotypes.
2. Click on the "Sync" tab
3. Choose an organism for which you know you have genotypes and click "Sync"

Using the main 7.x-3.x branch you would have see something like the following:
```
2018-07-03 19:54:22: Calling: nd_genotypes_update_mview(Array)
Updating the materialized views for the following partitions: Lens.

Partition: Lens...
   Sync'ing genotypes to the mview_ndg_calls mview...
    - Creating mview_ndg_lens_calls if it doesn't already exist...
Cannot modify header information - headers already sent by (output started at             [warning]
/usr/share/php/drush/includes/output.inc:37) common.inc:706
Drush command terminated abnormally due to an unrecoverable error.                        [error]
```

Using this branch you should see the following:
```
2018-07-03 20:04:26: Calling: nd_genotypes_update_mview(Array)
Updating the materialized views for the following partitions: Lens.

Partition: Lens...
   Sync'ing genotypes to the mview_ndg_calls mview...
    - Creating mview_ndg_lens_calls if it doesn't already exist...
    - Truncating mview_ndg_lens_calls...
    - Dropping indexes on mview_ndg_lens_calls...
       - Complete.
    - Determined there should be 8 chunks.
    - Working on genotype_id=2625647 (1 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625648 (2 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625649 (3 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625650 (4 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625651 (5 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625652 (6 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625653 (7 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Working on genotype_id=2625654 (8 of 8)...
       - Copying to file...
       - Copying it into the mview...
       - Finished Array records.
    - Creating Indexes
   Sync'ing genotypes to the mview_ndg_variants mview...
    - Creating mview_ndg_lens_variants if it doesn't already exist...
    - Truncating mview_ndg_lens_variants...
    - Dropping indexes on mview_ndg_lens_variants...
       - Complete.
    - Determined there should be 1 chunks.
WD nd_genotypes: Unable to populate materialized view due to incompatible postgresql      [error]
version. You are using 9.2 and this module requires at least 9.3.
[site http://default] [TRIPAL ERROR] [ND_GENOTYPES] Unable to populate materialized view due to incompatible postgresql version. You are using 9.2 and this module requires at least 9.3.
    - Working on  to 499999 (1 of 1)...
       - Copying to file...
       - Collapsing it to unique variants...
sort: open failed: /tmp/mview_ndg_variants.copy.unique: Permission denied
       - Copying it into the mview...
       - Finished Array records.
    - Creating Indexes
   Sync'ing genotypes to the mview_ndg_germplasm_genotyped mview...
    - Creating mview_ndg_germplasm_genotyped if it doesn't already exist...
    - Removing records related to this partition (lens)...
   Updating cached lists used for select boxes and what-not
    - Determining the types of variants...
    - Determining the types of markers...
Custom table, 'mview_ndg_lens_calls' , already exists. Table structure not changed, but   [status]
definition array has been saved.
Custom table, 'mview_ndg_lens_variants' , already exists. Table structure not changed, but[status]
definition array has been saved.
Custom table, 'mview_ndg_germplasm_genotyped' , already exists. Table structure not       [status]
changed, but definition array has been saved.
Custom table, 'mview_ndg_summary' , already exists. Table structure not changed, but      [status]
definition array has been saved.
```

Note: there is still an issue with sync'ing caused by issue #10 -it will be fixed in a future PR.