### PR TITLE
Handle postgresql versions better

### DIFF
--- a/api/nd_genotypes.api.inc
+++ b/api/nd_genotypes.api.inc
@@ -109,9 +109,17 @@ function nd_genotypes_recheck_postgresql_version() {
   // Determine the PostgreSQL version.
   $version_string = db_query('SELECT version()')->fetchField();
   $version = '9.2';
+
+  // Pull it out via REGEX.
   if (preg_match('/PostgreSQL (9\.\d+)\.\d+/', $version_string, $matches)) {
     $version = $matches[1];
   }
+
+  // If it's numeric then change it to a float for better comparison.
+  if (is_numeric($version)) {
+    $version = floatval($version);
+  }
+
   variable_set('pgsql_version', $version);
 
 }
@@ -120,7 +128,7 @@ function nd_genotypes_recheck_postgresql_version() {
  * Retrieve the postgresql version.
  */
 function nd_genotypes_get_postgresql_version() {
-  return variable_get('pgsql_version', '9.2');
+  return variable_get('pgsql_version', nd_genotypes_recheck_postgresql_version());
 }
 
 /**

--- a/includes/nd_genotypes.mview.inc
+++ b/includes/nd_genotypes.mview.inc
@@ -27,7 +27,7 @@
  */
 function nd_genotypes_create_mview_ndg_variants($tablename = 'mview_ndg_variants') {
 
-  $version = variable_get('pgsql_version', '9.2');
+  $version = variable_get('pgsql_version', 9.2);
 
   $schema = array(
     'description' => 'A listing of all the variants sorted by location.',
@@ -87,7 +87,7 @@ function nd_genotypes_create_mview_ndg_variants($tablename = 'mview_ndg_variants
         'name' => 'meta_data',
         'title' => 'Meta data',
         'description' => 'JSON storage of any addition meta-data for the call.',
-        'pgsql_type' => ($version == '9.4') ? 'jsonb' : 'json',
+        'pgsql_type' => ($version >= 9.4) ? 'jsonb' : 'json',
         'views_type' => 'text',
       ),
       'ndg_variants_id' => array(
@@ -176,7 +176,7 @@ function nd_genotypes_create_mview_ndg_variants_indexes($tablename = 'mview_ndg_
  */
 function nd_genotypes_create_mview_ndg_calls($tablename = 'mview_ndg_calls') {
 
-  $version = variable_get('pgsql_version', '9.2');
+  $version = variable_get('pgsql_version', 9.2);
 
   $schema = array(
     'description' => 'A listing of all the marker calls.',
@@ -273,7 +273,7 @@ function nd_genotypes_create_mview_ndg_calls($tablename = 'mview_ndg_calls') {
         'name' => 'meta_data',
         'title' => 'Meta data',
         'description' => 'JSON storage of any addition meta-data for the call.',
-        'pgsql_type' => ($version == '9.4') ? 'jsonb' : 'json',
+        'pgsql_type' => ($version >= 9.4) ? 'jsonb' : 'json',
         'views_type' => 'text',
       ),
       'ndg_call_id' => array(
@@ -516,7 +516,7 @@ function nd_genotypes_create_mview_summary($table_name = 'mview_ndg_summary') {
  */
 function nd_genotypes_genotype_call_schema_template() {
 
-  $version = variable_get('pgsql_version', '9.2');
+  $version = variable_get('pgsql_version', 9.2);
 
   return array(
     'description' => 'A more compact way to store genotype calls.',
@@ -572,7 +572,7 @@ function nd_genotypes_genotype_call_schema_template() {
         'name' => 'meta_data',
         'title' => 'Meta data',
         'description' => 'JSON storage of any addition meta-data for the call.',
-        'pgsql_type' => ($version == '9.4') ? 'jsonb' : 'json',
+        'pgsql_type' => ($version >= 9.4) ? 'jsonb' : 'json',
         'views_type' => 'text',
       ),
     ),

--- a/includes/nd_genotypes.mview.sync.inc
+++ b/includes/nd_genotypes.mview.sync.inc
@@ -230,7 +230,7 @@ function nd_genotypes_update_mview_ndg_variants($partition, $job_id) {
   // Because this only pulls from the calls which are already filtered to the given partition
   // we don't need to use the partition here.
   $variantprop_type_id = nd_genotypes_get_type_id('Variant Type');
-  if ($pg_version == '9.3') {
+  if ($pg_version == 9.3 ) {
   $query = "
       SELECT
         call.variant_id,
@@ -249,7 +249,7 @@ function nd_genotypes_update_mview_ndg_variants($partition, $job_id) {
       WHERE call.variant_id BETWEEN :min AND :max
       ";
   }
-  elseif ($pg_version == '9.4') {
+  elseif ($pg_version >= 9.4) {
     $query = "
       SELECT
         call.variant_id,

--- a/nd_genotypes.install
+++ b/nd_genotypes.install
@@ -11,6 +11,34 @@ function nd_genotypes_enable() {
   // Determine the PostgreSQL version.
   nd_genotypes_recheck_postgresql_version();
 
+  // Warn users if they don't have a high enough version.
+  $pg_version = nd_genotypes_get_postgresql_version();
+  drupal_set_message(t('Your postgresql version is: %curr', array('%curr' => $pg_version)));
+
+  // If not using PostgreSQL 9.3+, give an error
+  if (is_numeric($pg_version)) {
+    if ($pg_version < 9.3) {
+      drupal_set_message(t('This module requires PostgreSQL 9.3 or higher.'), 'error');
+
+      tripal_report_error(
+        'genotypes_loader',
+        TRIPAL_ERROR,
+        'Incompatible postgresql version detected. You are using :curr and this module requires at least 9.3.',
+        array( ':curr' => $pg_version )
+      );
+    }
+  }
+  else {
+    drupal_set_message(t('Could not determine current version of PostgreSQL. This module requires 9.3 or higher.'), 'error');
+
+    tripal_report_error(
+      'genotypes_loader',
+      TRIPAL_ERROR,
+      'Unable to determine postgresql version. You are using :curr and this module requires at least 9.3.',
+      array( ':curr' => $pg_version )
+    );
+  }
+
   // Ensure we have the vocab terms we would like to use as defaults.
   tripal_insert_cv(
     'MIXSCV',


### PR DESCRIPTION
Issue #10 

Originally this module didn't support version of postgresql > 9.4. Furthermore, all checks for postgresql version where string comparison (switched to float comparison in this PR) and there was bug that if the variable containing the version wasn't set, it wouldn't check but instead assumed you had 9.2...

Testing:
This one is difficult to test due to another bug in the mview sync. Instead, let's do a code review only at this point and we can re-open if the issue re-appears.

Note: I did test this by combining this PR with #12 and combined they allow sync'ing 🎉 