### PR TITLE
fix broken image in documentation

### DIFF
--- a/docs/features/sequence_with_variants_field.rst
+++ b/docs/features/sequence_with_variants_field.rst
@@ -8,7 +8,7 @@ This field adds a FASTA record showing the flanking sequence for the current mar
 
 Both the title and description of the figure legend can be configured by going to Administration » Structure » Tripal Content Types » [Variant/Marker] » Manage Display and clicking on the gear beside the genotype summary field.
 
-.. image:: sequence_with_Variants_field.2.config.png
+.. image:: sequence_with_variants_field.2.config.png
 
 .. warning::
 


### PR DESCRIPTION
the second [image here is a broken link
](https://nd-genotypes.readthedocs.io/en/latest/features/sequence_with_variants_field.html) in the RTD documentation in the features section.


![screen shot 2019-02-19 at 1 17 50 pm](https://user-images.githubusercontent.com/7063154/53037673-ce016b80-3448-11e9-8ad5-74983a088a46.png)

Looks to be a simple case issue as the file exists at https://github.com/UofS-Pulse-Binfo/nd_genotypes/blob/7.x-3.x/docs/features/sequence_with_variants_field.2.config.png


