### PR TITLE
Germplasm Maker Summary Field

### DIFF
--- a/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary.inc
+++ b/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary.inc
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide a graphical summary of data stored in a materialized view.
+ *   This is a generic, configurable fields to make it easier to add charts
+ *   to Tripal Content pages.
+ *
+ * Data:
+ *   Data is pulled from a configured materialized view and filtered based on a
+ *   specific Tripal/Chado field.
+ * Assumptions:
+ *   - Currently there can only be one such chart per page. If you need more then
+ *     one chart, a current work around is to extend this class using a different
+ *     term.
+ */
+class local__germ_marker_summary extends ChadoChartField {
+
+  // --------------------------------------------------------------------------
+  //                     EDITABLE STATIC CONSTANTS
+  //
+  // The following constants SHOULD be set for each descendent class.  They are
+  // used by the static functions to provide information to Drupal about
+  // the field and it's default widget and formatter.
+  // --------------------------------------------------------------------------
+
+  // The default lable for this field.
+  public static $default_label = 'Germplasm Marker Summary';
+
+  // The default description for this field.
+  public static $default_description = 'Germplasm Marker Summary';
+
+  // The default widget for this field.
+  public static $default_widget = 'local__germ_marker_summary_widget';
+
+  // The default formatter for this field.
+  public static $default_formatter = 'local__germ_marker_summary_formatter';
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instance.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings  = array(
+    // The short name for the vocabulary (e.g. shcema, SO, GO, PATO, etc.).
+    'term_vocabulary' => 'local',
+    // The name of the term.
+    'term_name' => 'germ_marker_summary',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => 'germ_marker_summary',
+    // Set to TRUE if the site admin is allowed to change the term
+    // type. This will create form elements when editing the field instance
+    // to allow the site admin to change the term settings above.
+    'term_fixed' => FALSE,
+    // The format for display of the organism.
+    'field_display_string' => '',
+  );
+
+  /// A boolean specifying that the field will not contain any data. This
+  // should exclude the field from web services or downloads.  An example
+  // could be a quick search field that appears on the page that redirects
+  // the user but otherwise provides no data.
+  public static $no_data = FALSE;
+
+
+  // ChadoFields automatically load the chado column specified in the
+  // default settings above. If that is all you need then you don't even
+  // need to implement this function. However, if you need to add any
+  // additional data to be used in the display, you should add it here.
+  public function load($entity) {
+    $germplasm = array(
+      // Chado record id coincides with stock.stock_id number
+      'stock_id' => $entity->chado_record_id,
+      // Genus
+      'genus' => $entity->chado_record->organism_id->genus,
+    );
+
+    // We need the field name to ensure we save the data in the correct field!
+    $field_name = $this->instance['field_name'];
+
+    // Set this property for formatteer to render.
+    $entity->{$field_name}['und'][0]['value']['local:germ_marker_summary'] = '';
+
+    // Save
+    $entity->{$field_name}['und'][0]['vars'] = array();
+
+    // This field will output a summary marker count of a germplasm.
+    // Markers : Summary count eg. 293,299 | Go to Genotype Matrix link.
+    $genotype_matrix_link = $GLOBALS['base_url'] . '/chado/genotype/' . ucfirst($germplasm['genus']) . '?germplasm[0]=' . $germplasm['stock_id'];
+
+    $summary_count = 0;
+
+    if (function_exists('ndg_mview_query')) {
+      // The genus of this germplasm. Use in identifying the partition in the function below.
+      $partition =  strtolower(trim($germplasm['genus']));
+
+      // Count markers for this germplasm.
+      $sql = sprintf("
+        SELECT COUNT(DISTINCT marker_id) AS summary_count
+        FROM {mview_ndg_calls} WHERE stock_id = %d OR germplasm_id = %d
+        LIMIT 1", $germplasm['stock_id'], $germplasm['stock_id']);
+
+      // Query materialized view, using the sql and partion.
+      $result = ndg_mview_query($partition, $sql);
+
+      if ($result) {
+        // Summary count of this stock.
+        $s = $result->fetchField();
+        $summary_count = number_format($s);
+      }
+    }
+
+    // Save
+    $entity->{$field_name}['und'][0]['vars'] = array(
+      'summary_count' => $summary_count,
+      'genotype_matrix' => $genotype_matrix_link,
+    );
+  }
+
+
+  /**
+   * Provides a form for the 'Field Settings' of an instance of this field.
+   *
+   * This function corresponds to the hook_field_instance_settings_form()
+   * function of the Drupal Field API.
+   *
+   * Validation of the instance settings form is not supported by Drupal, but
+   * the TripalField class does provide a mechanism for supporting validation.
+   * To allow for validation of your setting form you must call the parent
+   * in your child class:
+   *
+   * @code
+   *   $element = parent::instanceSettingsForm();
+   * @endcode
+   *
+   * Please note, the form generated with this function does not easily
+   * support AJAX calls in the same way that other Drupal forms do.  If you
+   * need to use AJAX you must manually alter the $form in your ajax call.
+   * The typical way to handle updating the form via an AJAX call is to make
+   * the changes in the form function itself but that doesn't work here.
+   */
+  public function instanceSettingsForm() {
+
+    // Retrieve the current settings.
+    // If this field was just created these will contain the default values.
+    $settings = $this->instance['settings'];
+
+    // Allow the parent Tripal Field to set up the form element for us.
+    $element = parent::instanceSettingsForm();
+
+
+    return $element;
+  }
+
+  /**
+   *
+   */
+  public function instanceSettingsFormValidate($form, &$form_state) {
+
+    parent::instanceSettingsFormValidate($form, $form_state);
+    $values = $form_state['values']['instance']['settings']['data_options'];
+
+  }
+}

--- a/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary.inc
+++ b/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary.inc
@@ -35,6 +35,9 @@ class local__germ_marker_summary extends ChadoChartField {
   // The default formatter for this field.
   public static $default_formatter = 'local__germ_marker_summary_formatter';
 
+  // The module that manages this field.
+  public static $module = 'nd_genotypes';
+
   // Provide a list of instance specific settings. These can be access within
   // the instanceSettingsForm.  When the instanceSettingsForm is submitted
   // then Drupal with automatically change these settings for the instance.

--- a/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary_formatter.inc
+++ b/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary_formatter.inc
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide a quick search on entity pages which submits/redirects to a full search.
+ *
+ * Display: A simple textfield search form.
+ * Configuration:
+ *   - path to the full search.
+ *   - the URL token (query parameter) the value applies to.
+ *   - help text.
+ *   - textfield placeholder.
+ *   - search button text.
+ *   - autocomplete path.
+ */
+class local__germ_marker_summary_formatter extends TripalFieldFormatter {
+  // The default label for this field.
+  public static $default_label = 'Germplasm Marker Summary';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('local__germ_marker_summary');
+
+  /**
+   *  Provides the display for a field
+   *
+   * This function corresponds to the hook_field_formatter_view()
+   * function of the Drupal Field API.
+   *
+   *  This function provides the display for a field when it is viewed on
+   *  the web page.  The content returned by the formatter should only include
+   *  what is present in the $items[$delta]['values] array. This way, the
+   *  contents that are displayed on the page, via webservices and downloaded
+   *  into a CSV file will always be identical.  The view need not show all
+   *  of the data in the 'values' array.
+   *
+   *  @param $element
+   *  @param $entity_type
+   *  @param $entity
+   *  @param $langcode
+   *  @param $items
+   *  @param $display
+   *
+   *  @return
+   *    An element array compatible with that returned by the
+   *    hook_field_formatter_view() function.
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+    // Grab the name of the field to create a unique ID for the chart.
+    $field_name = $this->instance['field_name'];
+    $display_vars = $entity->{$field_name}['und'][0]['vars'];
+
+    // Style information.
+    drupal_add_css(drupal_get_path('module', 'nd_genotypes') . '/includes/TripalFields/local__germ_marker_summary/theme/style_field.css');
+
+    $genotype_matrix_link = l(t('Go to Genotype Matrix'), $display_vars['genotype_matrix']);
+
+    // Add element:
+    $element[0] = array(
+      '#type' => 'markup',
+      '#markup' => '
+        <div id="field-germ-marker-summary-wrapper">
+          <div><h1>Makers: ' . $display_vars['summary_count']  . '</h1>&nbsp; | &nbsp;'. $genotype_matrix_link . '</div>
+        </div>
+      '
+    );
+
+    return $element;
+  }
+}

--- a/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary_widget.inc
+++ b/includes/TripalFields/local__germ_marker_summary/local__germ_marker_summary_widget.inc
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide a graphical summary of data stored in a materialized view.
+ *   This is a generic, configurable fields to make it easier to add charts
+ *   to Tripal Content pages.
+ *
+ * Allowing edit? No
+ */
+class local__germ_marker_summary_widget extends TripalFieldWidget {
+
+  // The default lable for this field.
+  public static $default_label = 'No Edits';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('local__germ_marker_summary');
+
+  /**
+   * Provides the form for editing of this field.
+   *
+   * This function corresponds to the hook_field_widget_form()
+   * function of the Drupal Field API.
+   *
+   * This form is diplayed when the user creates a new entity or edits an
+   * existing entity.  If the field is attached to the entity then the form
+   * provided by this function will be displayed.
+   *
+   * At a minimum, the form must have a 'value' element.  For Tripal, the
+   * 'value' element of a field always corresponds to the value that is
+   * presented to the end-user either directly on the page (with formatting)
+   * or via web services, or some other mechanism.  However, the 'value' is
+   * sometimes not enough for a field.  For example, the Tripal Chado module
+   * maps fields to table columns and sometimes those columns are foreign keys
+   * therefore, the Tripal Chado modules does not just use the 'value' but adds
+   * additional elements to help link records via FKs.  But even in this case
+   * the 'value' element must always be present in the return form and in such
+   * cases it's value should be set equal to that added in the 'load' function.
+   *
+   * @param $widget
+   * @param $form
+   *   The form structure where widgets are being attached to. This might be a
+   *   full form structure, or a sub-element of a larger form.
+   * @param $form_state
+   *   An associative array containing the current state of the form.
+   * @param $langcode
+   *   The language associated with $items.
+   * @param $items
+   *   Array of default values for this field.
+   * @param $delta
+   *   The order of this item in the array of subelements (0, 1, 2, etc).
+   * @param $element
+   * A form element array containing basic properties for the widget:
+   *  - #entity_type: The name of the entity the field is attached to.
+   *  - #bundle: The name of the field bundle the field is contained in.
+   *  - #field_name: The name of the field.
+   *  - #language: The language the field is being edited in.
+   *  - #field_parents: The 'parents' space for the field in the form. Most
+   *    widgets can simply overlook this property. This identifies the location
+   *    where the field values are placed within $form_state['values'], and is
+   *    used to access processing information for the field through the
+   *    field_form_get_state() and field_form_set_state() functions.
+   *  - #columns: A list of field storage columns of the field.
+   *  - #title: The sanitized element label for the field instance, ready for
+   *    output.
+   *  - #description: The sanitized element description for the field instance,
+   *    ready for output.
+   *  - #required: A Boolean indicating whether the element value is required;
+   *    for required multiple value fields, only the first widget's values are
+   *    required.
+   *  - #delta: The order of this item in the array of subelements; see
+   *    $delta above
+   */
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+   * Performs validation of the widgetForm.
+   *
+   * Use this validate to ensure that form values are entered correctly.
+   * The 'value' key of this field must be set in the $form_state['values']
+   * array anytime data is entered by the user.  It may be the case that there
+   * are other fields for helping select a value. In the end those helper
+   * fields must be used to set the 'value' field.
+   */
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+  /**
+   * Performs extra commands when the entity form is submitted.
+   *
+   * Drupal typically does not provide a submit hook for fields.  The
+   * TripalField provides one to allow for behind-the-scenes actions to
+   * occur.   This function should never be used for updates, deletes or
+   * inserts for the Chado table associated with the field.  Rather, the
+   * storage backend should be allowed to handle inserts, updates deletes.
+   * However, it is permissible to perform inserts, updates or deletions within
+   * Chado using this function.  Those operations can be performed if needed but
+   * on other tables not directly associated with the field.
+   *
+   * An example is the chado.feature_synonym table.  The chado_linker__synonym
+   * field allows the user to provide a brand new synonynm and it must add it
+   * to the chado.synonym table prior to the record in the
+   * chado.feature_synonym table.  This insert occurs in the widgetFormSubmit
+   * function.
+   *
+   *  @param $entity_type
+   *    The type of $entity.
+   *  @param $entity
+   *    The entity for the operation.
+   *  @param $field
+   *    The field structure for the operation.
+   *  @param $instance
+   *    The instance structure for $field on $entity's bundle.
+   *  @param $langcode
+   *    The language associated with $items.
+   *  @param $items
+   *    $entity->{$field['field_name']}[$langcode], or an empty array if unset.
+   *  @param $form
+   *    The submitted form array.
+   *  @param $form_state.
+   *    The form state array.
+   */
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+}

--- a/includes/TripalFields/local__germ_marker_summary/theme/style_field.css
+++ b/includes/TripalFields/local__germ_marker_summary/theme/style_field.css
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * Style germ_marker_summary field.
+ */
+
+/**
+ * Field wrapper
+ */
+#field-germ-marker-summary-wrapper {
+  background: #F9F9F9;
+  border: 1px solid #ECECEC;
+  padding: 20px;
+}
+
+#field-germ-marker-summary-wrapper h1 {
+  display: inline;
+}

--- a/nd_genotypes.install
+++ b/nd_genotypes.install
@@ -92,6 +92,35 @@ function nd_genotypes_install() {
 
   // Give them some guidance!
   drupal_set_message('In order to see the genotype and sequence pane on feature nodes, you have to set the type(s) used for variants and markers in the module settings. Click the configure link beside the module name.','warning');
+
+
+  // Register term required by Germplasm Marker Summary field.
+  $germ_marker_summary = array(
+    'id' => 'local:germ_marker_summary',
+    'name' => 'germ_marker_summary',
+    'cv_name' => 'local',
+    'definition' => 'Germplasm Marker Summary',
+  );
+
+  // Test term to ensure no duplicate exists in the system.
+  $is_in = FALSE;
+
+  if (function_exists('chado_get_cvterm')) {
+    $is_in = chado_get_cvterm($germ_marker_summary);
+  }
+  else {
+    $is_in = tripal_get_cvterm($germ_marker_summary);
+  }
+
+  if (!$is_in) {
+    // Is clear, insert term.
+    if (function_exists('cahdo_insert_cvterm')) {
+      chado_insert_cvterm($germ_marker_summary);
+    }
+    else {
+      tripal_insert_cvterm($germ_marker_summary);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue  Germplasm Marker Summary Field - https://github.com/UofS-Pulse-Binfo/nd_genotypes/issues/24

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [X] My code follows the code style of this project.
dependent on ND Genotypes API
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
![screen shot 2019-02-27 at 2 28 52 pm 2](https://user-images.githubusercontent.com/15472253/53520810-22859600-3a9c-11e9-8cf7-86b29d0fd0e1.png)

Implement a Tripal 3 field that summarizes the number of makers per type with call for the current germplasm.

Please note that upon install of ND Genotypes module, a term is added into the system.
Term: Germplasm Marker Summary; germ_marker_summary (local:germ_marker_summary)

## Testing?
1. Enable ND Genotypes.
2. Add a field and set the field type to Germplasm Marker Summary.
3. Enabled field in Manage Display.
4. Load a content where this field is available.

- [ ] I tested on a generic Tripal Site
- [X] I tested on a KnowPulse Clone 
- [ ] This PR includes automated testing
