### PR TITLE
Support 2-digit version strings.

### DIFF
--- a/api/nd_genotypes.api.inc
+++ b/api/nd_genotypes.api.inc
@@ -117,8 +117,8 @@ function nd_genotypes_recheck_postgresql_version() {
   $version = NULL;
 
   // Pull it out via REGEX.
-  drupal_set_message('Your version is reported as "'.$version_string.'".');
-  if (preg_match('/PostgreSQL (\d+\.\d+)\.\d+/', $version_string, $matches)) {
+  // @debug drupal_set_message('Your version is reported as "'.$version_string.'".');
+  if (preg_match('/PostgreSQL (\d+\.\d+)/', $version_string, $matches)) {
     $version = $matches[1];
   }
 

--- a/tests/api/dbTest.php
+++ b/tests/api/dbTest.php
@@ -18,11 +18,30 @@ class dbTest extends TripalTestCase {
   use DBTransaction;
 
   /**
-   * Basic test example.
-   * Tests must begin with the word "test".
-   * See https://phpunit.readthedocs.io/en/latest/ for more information.
+   * Tests nd_genotypes_get_postgresql_version() 
+   * and nd_genotypes_recheck_postgresql_version().
    */
-  public function testBasicExample() {
-    $this->assertTrue(true);
+  public function testGetPsqlVersion() {
+
+    // Retrieve the version.
+    // Ensure we are not simply testing a cached version.
+    nd_genotypes_recheck_postgresql_version(); 
+    $result = nd_genotypes_get_postgresql_version();
+
+    // Check that a version was returned.
+    $this->assertNotEmpty($result, "Unable to detect PostgreSQL version.");
+    $this->assertIsFloat($result, "Returned PosgreSQL version was not a float.");
+
+    // Check that it is the correct version.
+    $full_version = db_query('SELECT version()')->fetchField();
+    $this->assertContains( (string)$result, $full_version,
+      "The reported version is not in the original version string from PosgreSQL.");
+
+    // Check that rechecking the version does not change it.
+    $first = $result;
+    nd_genotypes_recheck_postgresql_version();
+    $second = nd_genotypes_get_postgresql_version();
+    $this->assertEquals($first, $second, 
+      "Re-checking the postgreSQL version should not change the result.");
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #26 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon nothing

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
Our version has the following format: `PostgreSQL 9.4.10 on x86_64-unknown-linux-gnu, compiled by gcc (Debian 4.9.2-10) 4.9.2, 64-bit` whereas, @bradfordcondon's is `PostgreSQL 10.5 on x86_64-apple-darwin, compiled by i686-apple-darwin11-llvm-gcc-4.2 (GCC) 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00), 64-bit`. Notice the difference between a 3-digit version string (`Postgresql 9.4.10`) and a 2-digit version string (`10.4`). This broke our regex to test for the version and this PR fixes that.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [x] This PR includes automated testing

The following php code can be used to test the version:
```php
nd_genotypes_recheck_postgresql_version();
dpm(variable_get('pgsql_version', FALSE), 'version');
```